### PR TITLE
refactor: use PushSecret only for vCluster credentials template

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 argocd 2.14.11
 k3d 5.8.3
 vcluster 0.24.1
+kubectl 1.31.0

--- a/stacks/virtual-cluster/helm-chart/helm-chart.yaml
+++ b/stacks/virtual-cluster/helm-chart/helm-chart.yaml
@@ -7,12 +7,12 @@ valuesInline:
   experimental:
     deploy:
       host:
-        # TODO: Refactor using PushSecret template only (no need for ExternalSecret) when this issue is solved:
-        # https://github.com/external-secrets/external-secrets/issues/3443
         manifestsTemplate: |
           ---
-          # Push the vCluster credentails to KubeZero ClusterSecretStore
-          # which will save it to KubeZero namespace.
+          # Push the vCluster credentails to KubeZero ClusterSecretStore,
+          # which will save it as a Secret in the KubeZero namespace to be used as an Argo CD cluster config
+          # (just a secret with a specific label).
+          # https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#clusters
           apiVersion: external-secrets.io/v1alpha1
           kind: PushSecret
           metadata:
@@ -28,64 +28,32 @@ valuesInline:
                 name: vc-{{ .Release.Name }}
             data:
               - match:
-                  secretKey: certificate-authority
+                  secretKey: name
                   remoteRef:
                     remoteKey: argo-cd-{{ .Release.Name }}-credentials
-                    property: caData
+                    property: name
               - match:
-                  secretKey: client-certificate
+                  secretKey: server
                   remoteRef:
                     remoteKey: argo-cd-{{ .Release.Name }}-credentials
-                    property: certData
+                    property: server
               - match:
-                  secretKey: client-key
+                  secretKey: config
                   remoteRef:
                     remoteKey: argo-cd-{{ .Release.Name }}-credentials
-                    property: keyData
-          ---
-          # Create an Argo CD cluster config (a secret with a specific label).
-          # https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#clusters
-          apiVersion: external-secrets.io/v1
-          kind: ExternalSecret
-          metadata:
-            name: argo-cd-{{ .Release.Name }}
-            namespace: kubezero
-          spec:
-            refreshInterval: 5m
-            secretStoreRef:
-              name: kubezero-management
-              kind: ClusterSecretStore
-            target:
-              template:
-                engineVersion: v2
-                metadata:
-                  annotations:
-                    managed-by: external-secrets
-                  labels:
-                    argocd.argoproj.io/secret-type: cluster
-                data:
-                  name: {{ .Release.Name }}
-                  server: https://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:443
-                  config: |
-                    {
-                      "tlsClientConfig": {
-                        "insecure": false,
-                        "caData": "{{ printf "{{ .caData | b64enc }}" }}",
-                        "certData": "{{ printf "{{ .certData | b64enc }}" }}",
-                        "keyData": "{{ printf "{{ .keyData | b64enc }}" }}",
-                        "serverName": "{{ .Release.Name }}"
-                      }
+                    property: config
+            template:
+              engineVersion: v2
+              data:
+                name: {{ .Release.Name }}
+                server: https://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:443
+                config: |
+                  {
+                    "tlsClientConfig": {
+                      "insecure": false,
+                      "caData": "{{ printf "{{ index . "certificate-authority" | b64enc }}" }}",
+                      "certData": "{{ printf "{{ index . "client-certificate" | b64enc }}" }}",
+                      "keyData": "{{ printf "{{ index . "client-key" | b64enc }}" }}",
+                      "serverName": "{{ .Release.Name }}"
                     }
-            data:
-            - secretKey: caData
-              remoteRef:
-                key: argo-cd-{{ .Release.Name }}-credentials
-                property: caData
-            - secretKey: certData
-              remoteRef:
-                key: argo-cd-{{ .Release.Name }}-credentials
-                property: certData
-            - secretKey: keyData
-              remoteRef:
-                key: argo-cd-{{ .Release.Name }}-credentials
-                property: keyData
+                  }


### PR DESCRIPTION
After another look, I noticed that the issue with PushSecret wasn't a bug but unclear documentation.

I've created a [PR in the External Secret project](https://github.com/external-secrets/external-secrets/pull/4872) to enhance the docs and refactor the vCluster credentials template to work with PushSecret only, eliminating the need for the `ExternalSecret` object.

I already tested the change, and it works as expected.