### PR TITLE
feat(iac providers) add initial setup of eks mgmt cluster iac

### DIFF
--- a/packages/aws-management/README.md
+++ b/packages/aws-management/README.md
@@ -1,0 +1,45 @@
+# KubeZero AWS Management Package
+
+This package provides a GitOps-ready Crossplane setup for managing an EKS cluster and its supporting AWS infrastructure on AWS, using Upbound's platform resources and Kustomize.
+
+## Structure
+- `infrastructure/xeks.yaml`: Defines the EKS cluster using the `XEKS` kind. Edit this file to set cluster version, node count, instance type, and other EKS parameters.
+- `infrastructure/xnetwork.yaml`: Defines the VPC and subnets using the `XNetwork` kind. Edit this file to set VPC CIDR, subnet CIDRs, and availability zones.
+- `infrastructure/kustomization.yaml`: Kustomize entrypoint for infrastructure resources.
+- `provider/`: Contains Crossplane provider configuration and the Upbound configuration package manifest.
+- `kustomization.yaml`: Top-level Kustomize entrypoint for the package.
+- `gitops.yaml`: ArgoCD AppProject and Application definitions for GitOps deployment.
+
+## Usage
+
+To use this package:
+
+1. **Copy the package**
+   - Copy the entire `aws-management` folder into your `registry` directory (e.g., `registry/aws-management`).
+     ```shell
+     cp -a packages/aws-management registry/aws-management
+     ```
+   - (Optional) Commit it to your repository:
+     ```shell
+     git add registry/aws-management
+     git commit -m "feat: enable aws-management package"
+     ```
+
+2. **Configure AWS Provider Credentials**
+   - Ensure a Kubernetes secret named `aws-creds` exists in the `crossplane-system` namespace with your AWS credentials.
+   - The provider config is defined in `provider/provider-config.yaml`.
+
+3. **Edit EKS and Network Parameters**
+   - Update `infrastructure/xeks.yaml` for EKS cluster settings (version, node count, instance type, etc).
+   - Update `infrastructure/xnetwork.yaml` for VPC and subnet settings (CIDR blocks, availability zones, etc).
+
+4. **Deploy with ArgoCD or Kustomize**
+   - **ArgoCD**: Point your Application at the `registry/aws-management` directory or use the provided `gitops.yaml`.
+   - **Kustomize**: From the package root, run:
+     ```sh
+     kustomize build . | kubectl apply -f -
+     ```
+## Notes
+- All configuration is done by editing the YAML manifests directly.
+- The Upbound configuration package is referenced in `provider-config/configuration.yaml`.
+- For advanced customization, refer to the Upbound [configuration-aws-eks documentation](https://marketplace.upbound.io/providers/upbound/configuration-aws-eks).

--- a/packages/aws-management/gitops.yaml
+++ b/packages/aws-management/gitops.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: aws-management
+spec:
+  description: Management EKS cluster resources
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  sourceRepos:
+    - https://github.com/kubezero/kubezero
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-management
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: aws-management
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/aws-management
+    targetRevision: main
+  destination:
+    name: in-cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Replace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-provider
+  namespace: kubezero
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: aws-management
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/aws-management/provider
+    targetRevision: main
+  destination:
+    name: in-cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Replace=true

--- a/packages/aws-management/infrastructure/kustomization.yaml
+++ b/packages/aws-management/infrastructure/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: '100'
+resources:
+  - xeks.yaml
+  - xnetwork.yaml

--- a/packages/aws-management/infrastructure/xeks.yaml
+++ b/packages/aws-management/infrastructure/xeks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: XEKS
+metadata:
+  name: configuration-aws-eks
+spec:
+  parameters:
+    id: configuration-aws-eks
+    providerConfigName: provider-aws
+    # To set a custom region, specify availability zones in the XNetwork
+    # for all subnets. If not set, the default region and zones are used.
+    # region: eu-west-1
+    version: "1.28"
+    accessConfig:
+      authenticationMode: API_AND_CONFIG_MAP
+      bootstrapClusterCreatorAdminPermissions: true
+    nodes:
+      count: 1
+      instanceType: t3.small
+  writeConnectionSecretToRef:
+    name: configuration-aws-eks-kubeconfig
+    namespace: crossplane-system

--- a/packages/aws-management/infrastructure/xnetwork.yaml
+++ b/packages/aws-management/infrastructure/xnetwork.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: XNetwork
+metadata:
+  name: configuration-aws-network
+spec:
+  parameters:
+    id: configuration-aws-eks
+    providerConfigName: provider-aws
+    # Setting a custom region requires explicitly specifying
+    # availability zones for all subnets. If omitted, the
+    # default region and its zones will be used.
+    # region: eu-west-1
+    # vpcCidrBlock: 192.168.0.0/16
+    # subnets:
+    #   - availabilityZone: eu-west-1a
+    #     type: public
+    #     cidrBlock: 192.168.0.0/18
+    #   - availabilityZone: eu-west-1b
+    #     type: public
+    #     cidrBlock: 192.168.64.0/18
+    #   - availabilityZone: eu-west-1a
+    #     type: private
+    #     cidrBlock: 192.168.128.0/18
+    #   - availabilityZone: eu-west-1b
+    #     type: private
+    #     cidrBlock: 192.168.192.0/18

--- a/packages/aws-management/kustomization.yaml
+++ b/packages/aws-management/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./infrastructure

--- a/packages/aws-management/provider/configuration.yaml
+++ b/packages/aws-management/provider/configuration.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-aws-eks
+spec:
+  package: xpkg.upbound.io/upbound/configuration-aws-eks:v0.24.0

--- a/packages/aws-management/provider/kustomization.yaml
+++ b/packages/aws-management/provider/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: '100'
+resources:
+  - configuration.yaml
+  - provider-config.yaml

--- a/packages/aws-management/provider/provider-config.yaml
+++ b/packages/aws-management/provider/provider-config.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: provider-aws
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-creds
+      key: creds


### PR DESCRIPTION
This PR introduces a production-ready AWS EKS management cluster package for KubeZero, implemented with Crossplane and structured according to KubeZero best practices.

The new `management-eks` directory contains modular Crossplane manifests for ProviderConfig, VPC, EKS cluster, and NodeGroup, along with Kustomize and ArgoCD GitOps integration.

This enables GitOps-driven, repeatable provisioning of the management cluster on AWS, and aligns with the documented KubeZero directory responsibilities.