### PR TITLE
feat: enhance devex

### DIFF
--- a/.github/workflows/pre-commit-checks.yaml
+++ b/.github/workflows/pre-commit-checks.yaml
@@ -5,9 +5,13 @@ on:
   pull_request:
     branches:
       - "*"
+  push:
+    branches:
+      - main
 
 jobs:
-  pre-commit:
+  lint:
+    name: Lint & Validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -16,24 +20,42 @@ jobs:
       - name: Install asdf & tools
         uses: asdf-vm/actions/install@v4
 
-      - name: Run pre-commit hooks
+      - name: Install kustomize
         run: |
-          pre-commit run --all-files
+          curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
+          sudo mv kustomize /usr/local/bin/
 
-      - name: Run gitleaks
-        run: |
-          gitleaks detect --source . --no-git --redact
+      - name: yamllint
+        run: yamllint .
 
-      - name: Run yamllint
-        run: |
-          yamllint .
+      - name: gitleaks
+        run: gitleaks detect --source . --no-git --redact
 
-      - name: Run kubeconform linter
+      - name: kubeconform (kustomize build)
         run: |
           chmod +x .hooks/kubeconform.sh
-          ./.hooks/kubeconform.sh || exit 1
+          .hooks/kubeconform.sh
 
-      - name: Run kube-score static analysis
+      - name: kube-score (kustomize build)
         run: |
           chmod +x .hooks/kube-score.sh
-          ./.hooks/kube-score.sh || exit 1
+          .hooks/kube-score.sh
+
+  cli-build:
+    name: CLI Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Build CLI
+        run: cd cli && go build ./...
+
+      - name: Vet CLI
+        run: cd cli && go vet ./...

--- a/.hooks/kube-score.sh
+++ b/.hooks/kube-score.sh
@@ -1,4 +1,34 @@
 #!/bin/bash
-for file in "$@"; do
-  kube-score score "$file"
+# Run kube-score on rendered kustomize output.
+# Usage: kube-score.sh [dirs...]
+#   If no dirs given, discovers all kustomization.yaml directories under
+#   modules/, stacks/, packages/, and controller/.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ $# -gt 0 ]; then
+  dirs=("$@")
+else
+  mapfile -t dirs < <(
+    find "$ROOT"/modules "$ROOT"/stacks "$ROOT"/packages "$ROOT"/controller \
+      -name "kustomization.yaml" -not -path "*/helm-chart/*" \
+      | xargs -I{} dirname {} \
+      | sort -u
+  )
+fi
+
+failed=0
+for dir in "${dirs[@]}"; do
+  rel="${dir#$ROOT/}"
+  output=$(kustomize build "$dir" 2>&1) || { echo "SKIP $rel (kustomize build failed)"; continue; }
+  if echo "$output" | kube-score score - --output-format ci 2>&1; then
+    echo "OK   $rel"
+  else
+    echo "WARN $rel (kube-score findings above)"
+    # kube-score findings are warnings, not hard failures
+  fi
 done
+
+exit $failed

--- a/.hooks/kubeconform.sh
+++ b/.hooks/kubeconform.sh
@@ -1,9 +1,43 @@
 #!/bin/bash
+# Validate rendered kustomize output with kubeconform.
+# Usage: kubeconform.sh [dirs...]
+#   If no dirs given, discovers all kustomization.yaml directories under
+#   modules/, stacks/, packages/, and controller/.
 
-kubeconform \
-  -summary \
-  -strict \
-  -ignore-missing-schemas \
-  -skip "CustomResourceDefinition" \
-  -ignore-filename-pattern "^\..+" \
-  "$@"
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+run_kubeconform() {
+  kubeconform \
+    -summary \
+    -strict \
+    -ignore-missing-schemas \
+    -skip "CustomResourceDefinition" \
+    -output pretty
+}
+
+if [ $# -gt 0 ]; then
+  dirs=("$@")
+else
+  mapfile -t dirs < <(
+    find "$ROOT"/modules "$ROOT"/stacks "$ROOT"/packages "$ROOT"/controller \
+      -name "kustomization.yaml" -not -path "*/helm-chart/*" \
+      | xargs -I{} dirname {} \
+      | sort -u
+  )
+fi
+
+failed=0
+for dir in "${dirs[@]}"; do
+  rel="${dir#$ROOT/}"
+  output=$(kustomize build "$dir" 2>&1) || { echo "SKIP $rel (kustomize build failed)"; continue; }
+  if echo "$output" | run_kubeconform; then
+    echo "OK   $rel"
+  else
+    echo "FAIL $rel"
+    failed=1
+  fi
+done
+
+exit $failed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,26 +6,28 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: local
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.32.0
     hooks:
-      - id: kubeconform
-        name: kubeconform linter
-        entry: .hooks/kubeconform.sh
-        language: script
-        files: \.ya?ml$
-
-      - id: kube-score
-        name: kube-score static analysis
-        entry: .hooks/kube-score.sh
-        language: script
-        files: \.ya?ml$
+      - id: yamllint
 
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.18.0
     hooks:
       - id: gitleaks
 
-  - repo: https://github.com/adrienverge/yamllint
-    rev: v1.32.0
+  - repo: local
     hooks:
-      - id: yamllint
+      - id: kubeconform
+        name: kubeconform (kustomize build)
+        entry: .hooks/kubeconform.sh
+        language: script
+        pass_filenames: false
+        always_run: true
+
+      - id: kube-score
+        name: kube-score (kustomize build)
+        entry: .hooks/kube-score.sh
+        language: script
+        pass_filenames: false
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+.PHONY: help bootstrap teardown validate registry-add registry-remove scaffold cli-build cli-install
+
+BOOTSTRAP_CONFIG ?= bootstrap/k3d-bootstrap-cluster.yaml
+CLUSTER_NAME     ?= kubezero
+
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ { printf "  %-22s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+# ── Bootstrap ──────────────────────────────────────────────────────────────────
+
+bootstrap: ## Create the local k3d bootstrap cluster
+	k3d cluster create --config $(BOOTSTRAP_CONFIG)
+
+teardown: ## Delete the local k3d bootstrap cluster
+	k3d cluster delete $(CLUSTER_NAME)
+
+# ── Registry management ────────────────────────────────────────────────────────
+
+registry-add: ## Copy a package into registry/ (usage: make registry-add PACKAGE=aws-management)
+ifndef PACKAGE
+	$(error PACKAGE is required. Example: make registry-add PACKAGE=aws-management)
+endif
+	@if [ -d registry/$(PACKAGE) ]; then \
+	  echo "registry/$(PACKAGE) already exists — skipping"; \
+	else \
+	  cp -r packages/$(PACKAGE) registry/$(PACKAGE); \
+	  echo "Added registry/$(PACKAGE)"; \
+	fi
+
+registry-remove: ## Remove a package from registry/ (usage: make registry-remove PACKAGE=aws-management)
+ifndef PACKAGE
+	$(error PACKAGE is required. Example: make registry-remove PACKAGE=aws-management)
+endif
+	@if [ ! -d registry/$(PACKAGE) ]; then \
+	  echo "registry/$(PACKAGE) does not exist — nothing to remove"; \
+	else \
+	  rm -rf registry/$(PACKAGE); \
+	  echo "Removed registry/$(PACKAGE)"; \
+	fi
+
+registry-list: ## List all packages and their activation status in registry/
+	@echo "Available packages (packages/):"
+	@ls packages/ | sed 's/^/  /'
+	@echo ""
+	@echo "Active registry entries (registry/):"
+	@for d in registry/*/; do \
+	  name=$$(basename "$$d"); \
+	  if [ -f "$$d/gitops.yaml" ]; then \
+	    echo "  $$name  (active)"; \
+	  elif [ -d "$$d" ]; then \
+	    echo "  $$name  (template)"; \
+	  fi; \
+	done || echo "  none"
+
+# ── Scaffold ───────────────────────────────────────────────────────────────────
+
+scaffold: ## Scaffold a new package (usage: make scaffold CLOUD=aws ROLE=worker)
+ifndef CLOUD
+	$(error CLOUD is required. Example: make scaffold CLOUD=aws ROLE=worker)
+endif
+ifndef ROLE
+	$(error ROLE is required. Example: make scaffold CLOUD=aws ROLE=worker)
+endif
+	cd cli && go run main.go scaffold --cloud $(CLOUD) --role $(ROLE) --repo ..
+
+# ── Validation ─────────────────────────────────────────────────────────────────
+
+validate: ## Run kubeconform + kube-score on all kustomize builds
+	chmod +x .hooks/kubeconform.sh .hooks/kube-score.sh
+	.hooks/kubeconform.sh
+	.hooks/kube-score.sh
+
+validate-kubeconform: ## Run kubeconform only
+	chmod +x .hooks/kubeconform.sh
+	.hooks/kubeconform.sh
+
+validate-kube-score: ## Run kube-score only
+	chmod +x .hooks/kube-score.sh
+	.hooks/kube-score.sh
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+cli-build: ## Build the kubezero CLI binary
+	cd cli && go build -o ../bin/kubezero .
+
+cli-install: ## Install the kubezero CLI to /usr/local/bin
+	cd cli && go build -o /usr/local/bin/kubezero .
+
+cli-vet: ## Run go vet on the CLI
+	cd cli && go vet ./...

--- a/cli/cmd/scaffold.go
+++ b/cli/cmd/scaffold.go
@@ -1,0 +1,507 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ── scaffold templates ────────────────────────────────────────────────────────
+
+// scaffoldTemplates defines the files generated for each cloud provider.
+// Keys are file paths relative to the new package root.
+type scaffoldTemplate struct {
+	gitops         string
+	infraKust      string
+	appKust        string
+	extraFiles     map[string]string // extra files relative to infrastructure/
+}
+
+var scaffoldTemplates = map[string]scaffoldTemplate{
+	"aws": {
+		gitops: `---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {name}
+spec:
+  description: {role} EKS cluster resources
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  sourceRepos:
+    - https://github.com/kubezero/kubezero
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: aws-provider
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/infrastructure
+    targetRevision: main
+  destination:
+    name: in-cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}-applications
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: aws-provider
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/applications
+    targetRevision: main
+  destination:
+    name: {name}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+`,
+		infraKust: `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: {name}-
+
+resources:
+  - ../../../modules/aws/eks/provider
+  - ../../../stacks/eks-cluster
+
+patches:
+  - path: patch-xeks.yaml
+    target:
+      kind: XEKS
+      name: aws-eks
+  - path: patch-xnetwork.yaml
+    target:
+      kind: XNetwork
+      name: aws-network
+`,
+		extraFiles: map[string]string{
+			"patch-xeks.yaml": `---
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: XEKS
+metadata:
+  name: aws-eks
+spec:
+  providerConfigName: {name}-provider-aws
+  writeConnectionSecretToRef:
+    name: {name}-aws-eks-kubeconfig
+    namespace: crossplane-system
+`,
+			"patch-xnetwork.yaml": `---
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: XNetwork
+metadata:
+  name: aws-network
+spec:
+  parameters:
+    providerConfigName: {name}-provider-aws
+`,
+		},
+	},
+	"gcp": {
+		gitops: `---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {name}
+spec:
+  description: {role} GKE cluster resources
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  sourceRepos:
+    - https://github.com/kubezero/kubezero
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: gcp-provider
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/infrastructure
+    targetRevision: main
+  destination:
+    name: in-cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}-applications
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: gcp-provider
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/applications
+    targetRevision: main
+  destination:
+    name: {name}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+`,
+		infraKust: `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: {name}-
+
+resources:
+  - ../../../modules/gcp/gke/provider
+  - ../../../stacks/gke-cluster
+
+patches:
+  - path: patch-xgke.yaml
+    target:
+      kind: XGKE
+      name: gcp-gke
+`,
+		extraFiles: map[string]string{
+			"patch-xgke.yaml": `---
+apiVersion: gcp.platform.upbound.io/v1alpha1
+kind: XGKE
+metadata:
+  name: gcp-gke
+spec:
+  parameters:
+    providerConfigName: {name}-provider-gcp
+  writeConnectionSecretToRef:
+    name: {name}-gcp-gke-kubeconfig
+    namespace: crossplane-system
+`,
+		},
+	},
+	"digitalocean": {
+		gitops: `---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {name}
+spec:
+  description: {role} DOKS cluster resources
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  sourceRepos:
+    - https://github.com/kubezero/kubezero
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: digitalocean-provider
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/infrastructure
+    targetRevision: main
+  destination:
+    name: in-cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}-applications
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: digitalocean-provider
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/applications
+    targetRevision: main
+  destination:
+    name: {name}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+`,
+		infraKust: `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: {name}-
+
+resources:
+  - ../../../modules/digitalocean/provider
+  - ../../../stacks/doks-cluster
+`,
+		extraFiles: map[string]string{},
+	},
+	"virtual": {
+		gitops: `---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: {name}
+spec:
+  description: {role} vCluster resources
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  sourceRepos:
+    - https://github.com/kubezero/kubezero
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/infrastructure
+    targetRevision: main
+  destination:
+    name: in-cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {name}-applications
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: {name}
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/{name}/applications
+    targetRevision: main
+  destination:
+    name: {name}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+`,
+		infraKust: `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../stacks/virtual-cluster
+  - namespace.yaml
+`,
+		extraFiles: map[string]string{
+			"namespace.yaml": `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {name}
+`,
+		},
+	},
+}
+
+var appKustManagement = `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: {name}-
+
+resources:
+  - ../../../stacks/k8s-essentials/helm-chart
+  - ../../../controller
+`
+
+var appKustWorker = `---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: {name}-
+
+resources:
+  - ../../../stacks/k8s-essentials/helm-chart
+`
+
+// ── Command ───────────────────────────────────────────────────────────────────
+
+var (
+	scaffoldCloud string
+	scaffoldRole  string
+	scaffoldForce bool
+)
+
+var scaffoldCmd = &cobra.Command{
+	Use:   "scaffold",
+	Short: "Generate a new package from a template",
+	Long: `scaffold creates a new package under packages/ for the given cloud and role.
+It generates all required files following the same conventions as the built-in packages.
+
+Examples:
+  kubezero scaffold --cloud aws --role worker
+  kubezero scaffold --cloud digitalocean --role management
+  kubezero scaffold --cloud virtual --role worker`,
+	RunE: runScaffold,
+}
+
+func init() {
+	rootCmd.AddCommand(scaffoldCmd)
+	scaffoldCmd.Flags().StringVar(&scaffoldCloud, "cloud", "", "Cloud provider (aws, gcp, digitalocean, virtual)")
+	scaffoldCmd.Flags().StringVar(&scaffoldRole, "role", "", "Cluster role (management or worker)")
+	scaffoldCmd.Flags().BoolVar(&scaffoldForce, "force", false, "Overwrite if package already exists")
+	scaffoldCmd.Flags().StringVar(&repoRoot, "repo", "..", "Path to the kubezero repository root")
+	_ = scaffoldCmd.MarkFlagRequired("cloud")
+	_ = scaffoldCmd.MarkFlagRequired("role")
+}
+
+func runScaffold(_ *cobra.Command, _ []string) error {
+	cloud := strings.ToLower(scaffoldCloud)
+	role := strings.ToLower(scaffoldRole)
+
+	if _, ok := clouds[cloud]; !ok {
+		return fmt.Errorf("unknown cloud %q — valid options: aws, gcp, digitalocean, virtual", cloud)
+	}
+	if role != "management" && role != "worker" {
+		return fmt.Errorf("role must be 'management' or 'worker', got %q", role)
+	}
+
+	tmpl, ok := scaffoldTemplates[cloud]
+	if !ok {
+		return fmt.Errorf("no scaffold template for cloud %q", cloud)
+	}
+
+	name := cloud + "-" + role
+	pkgDir := filepath.Join(repoRoot, "packages", name)
+
+	if _, err := os.Stat(pkgDir); err == nil {
+		if !scaffoldForce {
+			return fmt.Errorf("package %s already exists — use --force to overwrite", name)
+		}
+		fmt.Printf("Overwriting existing package %s\n", name)
+	}
+
+	// Render all template variables
+	render := func(s string) string {
+		s = strings.ReplaceAll(s, "{name}", name)
+		s = strings.ReplaceAll(s, "{role}", role)
+		s = strings.ReplaceAll(s, "{cloud}", cloud)
+		return s
+	}
+
+	appKust := appKustWorker
+	if role == "management" {
+		appKust = appKustManagement
+	}
+
+	files := map[string]string{
+		"gitops.yaml":                        render(tmpl.gitops),
+		"infrastructure/kustomization.yaml":  render(tmpl.infraKust),
+		"applications/kustomization.yaml":    render(appKust),
+	}
+	for relPath, content := range tmpl.extraFiles {
+		files["infrastructure/"+relPath] = render(content)
+	}
+
+	for relPath, content := range files {
+		fullPath := filepath.Join(pkgDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", relPath, err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", relPath, err)
+		}
+		fmt.Printf("  wrote  packages/%s/%s\n", name, relPath)
+	}
+
+	fmt.Println()
+	fmt.Printf("Package packages/%s created.\n", name)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Printf("  1. Review packages/%s/ and adjust any values\n", name)
+	fmt.Printf("  2. Activate it:  make registry-add PACKAGE=%s\n", name)
+	fmt.Println("  3. Commit and push — ArgoCD will pick it up automatically")
+
+	return nil
+}

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -1,0 +1,268 @@
+# Adding a New Cloud Provider
+
+This guide walks through everything needed to add a new cloud provider (e.g. Azure AKS) to KubeZero following the same conventions as the existing providers.
+
+## Overview
+
+Adding a provider means adding four things in order:
+
+```
+modules/<cloud>/         ← Crossplane provider + cluster CRDs
+stacks/<cloud>-cluster/  ← Combine module + cluster-secret (ArgoCD registration)
+packages/<cloud>-*/      ← Ready-to-use management + worker bundles
+cli/cmd/scaffold.go      ← Template for kubezero scaffold
+```
+
+---
+
+## Step 1 — Add the Crossplane provider module
+
+Create `modules/<cloud>/provider/`:
+
+```
+modules/<cloud>/
+  provider/
+    configuration.yaml   ← Crossplane Configuration package CR
+    kustomization.yaml
+```
+
+**`configuration.yaml`** installs the Crossplane provider package:
+
+```yaml
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-<cloud>-<service>
+spec:
+  package: xpkg.upbound.io/upbound/configuration-<cloud>-<service>:vX.Y.Z
+```
+
+Find the latest version at [marketplace.upbound.io](https://marketplace.upbound.io).
+
+---
+
+## Step 2 — Add the cluster module
+
+Create `modules/<cloud>/cluster/` with these files:
+
+```
+modules/<cloud>/cluster/
+  kustomization.yaml
+  provider-config.yaml   ← ProviderConfig CR (credentials reference)
+  x<cluster>.yaml        ← Composite resource (XEKS / XGKE / XAKS …)
+  xnetwork.yaml          ← VPC / network composite resource
+```
+
+### `provider-config.yaml`
+
+```yaml
+---
+apiVersion: <cloud>.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: provider-<cloud>
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: <cloud>-creds    # REPLACE: create this secret manually
+      key: creds
+```
+
+### `x<cluster>.yaml`
+
+Use the high-level composite resource from the Upbound platform configuration:
+
+```yaml
+---
+apiVersion: <cloud>.platform.upbound.io/v1alpha1
+kind: X<Cluster>
+metadata:
+  name: <cloud>-cluster
+spec:
+  parameters:
+    id: <cloud>-cluster
+    region: <default-region>
+    version: latest
+    nodes:
+      count: 1
+      instanceType: <default-instance-type>
+  writeConnectionSecretToRef:
+    name: <cloud>-cluster-kubeconfig
+    namespace: crossplane-system
+```
+
+### `kustomization.yaml`
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - provider-config.yaml
+  - x<cluster>.yaml
+  - xnetwork.yaml
+```
+
+---
+
+## Step 3 — Add a cluster stack
+
+Create `stacks/<cloud>-cluster/`:
+
+```
+stacks/<cloud>-cluster/
+  kustomization.yaml
+  cluster-secret.yaml
+```
+
+### `kustomization.yaml`
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../modules/<cloud>/cluster
+  - ./cluster-secret.yaml
+```
+
+### `cluster-secret.yaml`
+
+This is the bridge between Crossplane and ArgoCD. It reads the kubeconfig Crossplane writes and transforms it into an ArgoCD cluster Secret.
+
+```yaml
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: <cloud>-cluster-secret
+  namespace: kubezero
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubezero-management
+  target:
+    name: <cloud>-cluster-secret
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+      data:
+        name: "{{ .name }}"
+        server: "{{ .server }}"
+        config: |
+          {
+            "tlsClientConfig": {
+              "insecure": false,
+              "caData": "{{ .caData }}"
+            },
+            "bearerToken": "{{ .token }}"
+          }
+  data:
+    - secretKey: name
+      remoteRef:
+        key: <cloud>-cluster-kubeconfig  # matches writeConnectionSecretToRef
+        property: endpoint               # adjust property names per provider
+    - secretKey: server
+      remoteRef:
+        key: <cloud>-cluster-kubeconfig
+        property: endpoint
+    - secretKey: caData
+      remoteRef:
+        key: <cloud>-cluster-kubeconfig
+        property: clusterCA
+    - secretKey: token
+      remoteRef:
+        key: <cloud>-cluster-kubeconfig
+        property: token
+```
+
+> **Note on auth:** Different clouds use different auth mechanisms in ArgoCD:
+> - AWS EKS: use `awsAuthConfig` with `clusterName`
+> - GCP GKE: use `execProviderConfig` with `argocd-k8s-auth gcp`
+> - Others: bearer token + CA (shown above)
+
+---
+
+## Step 4 — Add packages
+
+Create management and worker packages:
+
+```bash
+kubezero scaffold --cloud <cloud> --role management
+kubezero scaffold --cloud <cloud> --role worker
+```
+
+This generates `packages/<cloud>-management/` and `packages/<cloud>-worker/` with:
+- `gitops.yaml` — AppProject + Application CRs
+- `infrastructure/kustomization.yaml` — references stack + namePrefix
+- `applications/kustomization.yaml` — references k8s-essentials
+
+Then update `cli/cmd/scaffold.go` to add a proper template for the new cloud under `scaffoldTemplates` so future `scaffold` calls generate correct patch files.
+
+---
+
+## Step 5 — Add the credential secret
+
+The provider needs a Kubernetes Secret in `crossplane-system`. This is the one manual step that is intentionally not in the repo (never commit credentials).
+
+Create a script or document it in your runbook:
+
+```bash
+# Example: create the cloud credential secret
+kubectl create secret generic <cloud>-creds \
+  --namespace crossplane-system \
+  --from-file=creds=<path-to-credentials-file>
+```
+
+---
+
+## Step 6 — Update the CLI
+
+Add the new cloud to the `clouds` map in `cli/cmd/init.go`:
+
+```go
+"<cloud>": {
+    label: "<Cloud> (<Service>)",
+    regions: []string{
+        "region-1", "region-2",
+    },
+},
+```
+
+And add it to `cloudKeys` so it appears in `kubezero init`.
+
+---
+
+## Step 7 — Validate
+
+```bash
+# Verify kustomize build works for new modules/stacks/packages
+kustomize build modules/<cloud>/cluster
+kustomize build stacks/<cloud>-cluster
+kustomize build packages/<cloud>-management/infrastructure
+
+# Full validation
+make validate
+```
+
+---
+
+## Conventions checklist
+
+- [ ] `ProviderConfig` has `argocd.argoproj.io/sync-wave: "1"` annotation
+- [ ] Cluster composite resource writes to `crossplane-system` via `writeConnectionSecretToRef`
+- [ ] `cluster-secret.yaml` uses `ExternalSecret` pointing at `ClusterSecretStore/kubezero-management`
+- [ ] ArgoCD cluster Secret has label `argocd.argoproj.io/secret-type: cluster`
+- [ ] Package uses `namePrefix: <role>-` to avoid name collisions
+- [ ] Package `gitops.yaml` references `registry/<name>/` paths (not `packages/`)
+- [ ] Cloud added to `clouds` map and `cloudKeys` slice in `cli/cmd/init.go`
+- [ ] Scaffold template added to `scaffoldTemplates` in `cli/cmd/scaffold.go`

--- a/registry/virtual-management/applications/kustomization.yaml
+++ b/registry/virtual-management/applications/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: management-
+
+resources:
+  - ../../../stacks/k8s-essentials/helm-chart
+  - ../../../controller

--- a/registry/virtual-management/gitops.yaml
+++ b/registry/virtual-management/gitops.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: virtual-management
+spec:
+  description: Management GKE cluster resources
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  sourceRepos:
+    - https://github.com/kubezero/kubezero
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: virtual-management-infrastructure
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: vcluster
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: virtual-management-infrastructure
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/virtual-management/infrastructure
+    targetRevision: main
+  destination:
+    name: in-cluster
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: virtual-management-applications
+  annotations:
+    argocd.argoproj.io/sync-wave: '100'
+    argocd.argoproj.io/depends-on: vcluster
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: virtual-management
+  source:
+    repoURL: https://github.com/kubezero/kubezero
+    path: registry/virtual-management/applications
+    targetRevision: main
+  destination:
+    # NOTE: Change the name according to your cluster.
+    name: virtual-management
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true

--- a/registry/virtual-management/infrastructure/kustomization.yaml
+++ b/registry/virtual-management/infrastructure/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: virtual-management
+
+resources:
+  - ./namespace.yaml
+  - ../../../stacks/virtual-cluster/helm-chart
+
+patches:
+  - target:
+      kind: HelmChartInflationGenerator
+    patch: |-
+      apiVersion: builtin
+      kind: HelmChartInflationGenerator
+      metadata:
+        name: virtual-management
+      releaseName: virtual-management
+      namespace: virtual-management

--- a/registry/virtual-management/infrastructure/namespace.yaml
+++ b/registry/virtual-management/infrastructure/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: virtual-management


### PR DESCRIPTION
- fix kubeconform + kube-score hooks to run kustomize build first (not raw YAML)
- set pass_filenames: false in .pre-commit-config.yaml for kustomize-aware hooks
- enhance GH Actions workflow: split lint + cli-build jobs, run on push to main, install kustomize in CI
- add Makefile with bootstrap, teardown, registry-add/remove/list, validate, scaffold, cli-build targets
- add `kubezero scaffold --cloud <x> --role <y>` CLI command with templates for all 4 clouds
- add docs/adding-a-provider.md with 7-step guide + conventions checklist